### PR TITLE
Fix debian/watch file

### DIFF
--- a/debian-upstream/watch
+++ b/debian-upstream/watch
@@ -1,2 +1,3 @@
 version=3
-https://github.com/darealshinji/patchelfmod/releases archive/(.+)\.tar\.(?:xz|bz2|gz)
+https://github.com/darealshinji/patchelfmod/releases \
+    (?:.*/)?archive/(.+)\.tar\.(?:xz|bz2|gz)


### PR DESCRIPTION
The download link to the tarball has the full path.
So also match everything until the last slash just before the archive download location.
